### PR TITLE
:pencil2: Update login sections with new branding 

### DIFF
--- a/src/components/features/user-management/user-authentication/LoginLeftImageSection.tsx
+++ b/src/components/features/user-management/user-authentication/LoginLeftImageSection.tsx
@@ -24,11 +24,11 @@ export const LoginLeftImageSection: FC = () => {
               Welcome to
             </h2>
             <h3 className="text-xl lg:text-2xl font-semibold text-transparent bg-clip-text bg-gradient-to-r from-cyan-500 to-blue-600">
-              Katugahahena Hospital
+              GovConnect Officer Portal
             </h3>
             <p className="text-gray-600 leading-relaxed">
-              Resident Health Monitoring System - Secure staff portal for
-              comprehensive healthcare management
+              Connect with citizens, manage requests, and streamline your
+              administrative tasks efficiently.
             </p>
           </div>
         </div>

--- a/src/components/features/user-management/user-authentication/LoginRightLoginSection.tsx
+++ b/src/components/features/user-management/user-authentication/LoginRightLoginSection.tsx
@@ -64,10 +64,11 @@ export const LoginRightLoginSection: FC<UserLoginSectionProps> = ({
               <Building2 className="w-8 h-8 text-white" />
             </div>
             <Title level={3} className="text-gray-900 mb-2">
-              Staff Portal
+              Officer Login Portal
             </Title>
             <p className="text-gray-600">
-              Sign in to access the healthcare management system
+              Sign in to view bookings, manage requests, and access your
+              dashboard.
             </p>
           </div>
 


### PR DESCRIPTION
This pull request updates the login page messaging to better reflect the purpose and audience of the portal. The changes focus on rebranding the portal from a healthcare management system to the GovConnect Officer Portal, and clarifying its features for officers.

**Login page rebranding:**

* Updated the main heading and description in `LoginLeftImageSection.tsx` to "GovConnect Officer Portal" and revised the description to emphasize connecting with citizens and streamlining administrative tasks.
* Changed the title and description in `LoginRightLoginSection.tsx` from "Staff Portal" for healthcare management to "Officer Login Portal" with a focus on bookings, requests, and dashboard access.