### PR TITLE
:bug: Fix citizen link

### DIFF
--- a/src/components/layouts/admin/AdminSlidebar.tsx
+++ b/src/components/layouts/admin/AdminSlidebar.tsx
@@ -1,6 +1,5 @@
 import { FC, useEffect, useState } from "react";
 import { Link, NavLink, useNavigate } from "react-router";
-import { MdDashboard } from "react-icons/md";
 import { FaHouseUser } from "react-icons/fa";
 import { UserOutlined } from "@ant-design/icons";
 import { HiUsers } from "react-icons/hi";


### PR DESCRIPTION
This pull request refactors the `AdminSlidebar` component by removing the Dashboard and Citizens navigation items from the sidebar, along with their associated icon imports and rendering logic. The changes streamline the sidebar navigation to only include items present in the updated `navItems` array.

Navigation item removals:

* Removed the Dashboard navigation link and its associated icon import (`MdDashboard`) from `AdminSlidebar.tsx`, including all related rendering logic. [[1]](diffhunk://#diff-d63a5e17bcb4d9da511bd235d5f278cca1eaa98d58b9e8dfbc32ebd56110ec44L3) [[2]](diffhunk://#diff-d63a5e17bcb4d9da511bd235d5f278cca1eaa98d58b9e8dfbc32ebd56110ec44L98-L117)
* Removed the Citizens navigation item from the `navItems` array in `AdminSlidebar.tsx`.