### PR TITLE
:lipstick: Replace LandingHeader with CommonNav 

### DIFF
--- a/src/components/common/CommonNav.tsx
+++ b/src/components/common/CommonNav.tsx
@@ -1,0 +1,120 @@
+import { Layout, Menu, Avatar, Dropdown, Space, Typography } from "antd";
+import {
+  DashboardOutlined,
+  AppstoreOutlined,
+  CalendarOutlined,
+  FileTextOutlined,
+  UserOutlined,
+  InfoCircleOutlined,
+  MessageOutlined,
+
+} from "@ant-design/icons";
+import { useNavigate } from "react-router";
+
+const { Header } = Layout;
+const { Text } = Typography;
+
+const CommonNav = () => {
+  const navigate = useNavigate();
+
+  const handleMenuClick = (key: string) => {
+    switch (key) {
+      case "dashboard":
+        navigate("/dashboard");
+        break;
+      case "departments":
+        navigate("/departments");
+        break;
+      case "appointments":
+        navigate("/appointments");
+        break;
+      case "documents":
+        navigate("/documents");
+        break;
+      case "about":
+        navigate("/about");
+        break;
+      case "feedback":
+        navigate("/feedback");
+        break;
+      case "logout":
+        navigate("/login");
+        break;
+      case "profile":
+        navigate("/profile");
+        break;
+      default:
+        break;
+    }
+  };
+
+  const profileMenu = (
+    <Menu onClick={(e) => handleMenuClick(e.key)}>
+      <Menu.Item key="profile">Profile</Menu.Item>
+      <Menu.Item key="logout">Logout</Menu.Item>
+    </Menu>
+  );
+
+  return (
+    <Header
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "0 30px",
+        height: "80px",
+        backgroundColor: "#fff",
+        boxShadow: "0 2px 8px rgba(0,0,0,0.1)",
+      }}
+    >
+      {/* Left side: Product name + tagline */}
+      <div style={{ display: "flex", flexDirection: "column", justifyContent: "center" }}>
+        <Text style={{ fontSize: "22px", fontWeight: "bold", color: "#000" }}>
+          GovConnect
+        </Text>
+        <Text style={{ fontSize: "12px", color: "#555" }}>
+          Government Services Simplified!
+        </Text>
+      </div>
+
+      {/* Right side: Menu + Profile */}
+      <Space align="center">
+        <Menu
+          mode="horizontal"
+          defaultSelectedKeys={["dashboard"]}
+          style={{ background: "transparent", lineHeight: "80px" }}
+          onClick={(e) => handleMenuClick(e.key)}
+        >
+          <Menu.Item key="dashboard" icon={<DashboardOutlined />}>
+            Dashboard
+          </Menu.Item>
+          <Menu.Item key="departments" icon={<AppstoreOutlined />}>
+            Departments
+          </Menu.Item>
+          <Menu.Item key="appointments" icon={<CalendarOutlined />}>
+            Appointments
+          </Menu.Item>
+          <Menu.Item key="documents" icon={<FileTextOutlined />}>
+            Documents
+          </Menu.Item>
+          <Menu.Item key="about" icon={<InfoCircleOutlined />}>
+            About Us
+          </Menu.Item>
+          <Menu.Item key="feedback" icon={<MessageOutlined />}>
+            Feedback
+          </Menu.Item>
+        </Menu>
+
+        <Dropdown overlay={profileMenu} placement="bottomRight">
+          <Avatar
+            size="large"
+            icon={<UserOutlined />}
+            style={{ cursor: "pointer" }}
+          />
+        </Dropdown>
+      </Space>
+    </Header>
+  );
+};
+
+export default CommonNav;

--- a/src/pages/AppointmentBookingPage.tsx
+++ b/src/pages/AppointmentBookingPage.tsx
@@ -2,13 +2,13 @@ import { useState } from "react";
 import { useParams, useNavigate } from "react-router";
 import { Form, Card, Steps, Button, notification, Typography } from "antd";
 import { CalendarOutlined, ArrowLeftOutlined } from "@ant-design/icons";
-import { LandingHeader } from "../components/features/landing-page/LandingHeader";
 import StepServiceDate from "../components/features/appointment-booking/ServiceDate";
 import StepPersonalInfo from "../components/features/appointment-booking/PersonalInfo";
 import StepUploadDocuments from "../components/features/appointment-booking/UploadDocs";
 import StepConfirmation from "../components/features/appointment-booking/Confirmation";
 import FormNavigation from "../components/common/FormNavigation";
 import AppointmentSuccess from "../components/features/appointment-booking/AppointmentSuccess";
+import CommonNav from "../components/common/CommonNav";
 
 const AppointmentBookingPage = () => {
   const { serviceId } = useParams<{ serviceId: string }>();
@@ -95,7 +95,7 @@ const AppointmentBookingPage = () => {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <LandingHeader />
+      <CommonNav />
       <div className="mx-auto px-4 py-8" style={{ maxWidth: '1000px' }}>
         <Button type="text" icon={<ArrowLeftOutlined />} onClick={handleGoBack} className="mb-6">Back</Button>
 

--- a/src/pages/ServiceDetailPage.tsx
+++ b/src/pages/ServiceDetailPage.tsx
@@ -23,6 +23,7 @@ import {
     InfoCircleOutlined
 } from "@ant-design/icons";
 import { LandingHeader } from "../components/features/landing-page/LandingHeader";
+import CommonNav from "../components/common/CommonNav";
 
 const { Title, Paragraph, Text } = Typography;
 
@@ -294,7 +295,7 @@ const ServiceDetailPage = () => {
 
     return (
         <div className="min-h-screen bg-gray-50">
-            <LandingHeader />
+            <CommonNav />
 
             <div className="max-w-6xl mx-auto px-4 py-8">
                 {/* Back Button */}


### PR DESCRIPTION
This pull request introduces a new reusable navigation bar component and updates the navigation UI across key pages for a more consistent user experience. The most significant change is the creation and integration of the `CommonNav` component, which replaces the previous `LandingHeader` on appointment booking and service detail pages.

**Navigation Bar Improvements**

* Added a new `CommonNav` component in `src/components/common/CommonNav.tsx` that provides a consistent header with navigation menu, profile dropdown, and product branding.

**Page Updates**

* Replaced the usage of `LandingHeader` with `CommonNav` in `AppointmentBookingPage.tsx` and `ServiceDetailPage.tsx`, ensuring a unified navigation experience across these pages. [[1]](diffhunk://#diff-0b3de7a59be8a488ea753d7fe9dbd426f55c4f6bcb32c9705b74a8facd34cbb0L5-R11) [[2]](diffhunk://#diff-0b3de7a59be8a488ea753d7fe9dbd426f55c4f6bcb32c9705b74a8facd34cbb0L98-R98) [[3]](diffhunk://#diff-b18fb91a751a1082a0e6fb626a756e58ac0693b20f7f182e1a9197c841a1db83R26) [[4]](diffhunk://#diff-b18fb91a751a1082a0e6fb626a756e58ac0693b20f7f182e1a9197c841a1db83L297-R298)