### PR TITLE
:bug: fix redirect path after login to point to /admin/analytics

### DIFF
--- a/src/pages/admin/LoginPage.tsx
+++ b/src/pages/admin/LoginPage.tsx
@@ -13,14 +13,14 @@ const LoginPage: FC = () => {
   useEffect(() => {
     if (auth.isAuthenticated) {
       // Check if there's a redirect path from the location state
-      const from = location.state?.from || "/admin/dashboard";
+      const from = location.state?.from || "/admin/analytics";
       navigate(from, { replace: true });
     }
   }, [auth.isAuthenticated, navigate, location.state]);
 
   const handleSuccessLogin = () => {
     // Check if there's a redirect path from the location state
-    const from = location.state?.from || "/admin/dashboard";
+    const from = location.state?.from || "/admin/analytics";
     navigate(from, { replace: true });
   };
 


### PR DESCRIPTION
This pull request makes a minor update to the login redirect behavior for the admin section. After a successful login, users will now be redirected to the `/admin/analytics` page instead of the previous `/admin/dashboard` default.

* Changed the default post-login redirect path from `/admin/dashboard` to `/admin/analytics` in the `LoginPage` component.